### PR TITLE
feat: drag and drop

### DIFF
--- a/src/components/add-card/index.js
+++ b/src/components/add-card/index.js
@@ -73,7 +73,7 @@ document.querySelector("#app").addEventListener("click", (event) => {
   setLocalStorage("todolist", todolist);
 
   // TODO: user agent 파싱해서 author 추가하기
-  store.dispatch(addCard({ columnId, title, description, author }));
+  // store.dispatch(addCard({ columnId, title, description, author }));
 
   // NOTE: 특정 칼럼에 대한 카드 리렌더링
   const column = document.querySelector(

--- a/src/components/add-card/index.js
+++ b/src/components/add-card/index.js
@@ -1,6 +1,9 @@
 import { store } from "../../store/index.js";
 import { getLocalStorage, setLocalStorage } from "../../utils/local-storage.js";
+import { setEvent } from "../../utils/set-event.js";
 import * as Column from "../column/index.js";
+
+const app = document.getElementById("app");
 
 export function template({ columnId }) {
   return `
@@ -44,7 +47,7 @@ const render = () => {};
 store.subscribe(render);
 
 // 카드 등록
-document.querySelector("#app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const target = event.target.closest(".add-button");
   if (target === null) {
     return;
@@ -84,7 +87,7 @@ document.querySelector("#app").addEventListener("click", (event) => {
   })}`;
 });
 
-document.querySelector("#app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const target = event.target.closest(".cancel-button");
   if (target === null) {
     return;

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -4,6 +4,9 @@ import * as EditableCard from "../editable-card/index.js";
 import { getLocalStorage, setLocalStorage } from "../../utils/local-storage.js";
 import { store } from "../../store/index.js";
 import { getDragAfterElement } from "../../utils/get-drag-after-element.js";
+import { setEvent } from "../../utils/set-event.js";
+
+const app = document.getElementById("app");
 
 export function template({ columnId, card }) {
   return `
@@ -38,7 +41,7 @@ export function template({ columnId, card }) {
 const render = () => {};
 store.subscribe(render);
 
-document.getElementById("app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const cardDeleteButton = event.target.closest(".card__delete-button");
   if (cardDeleteButton === null) {
     return;
@@ -77,7 +80,7 @@ document.getElementById("app").addEventListener("click", (event) => {
   });
 });
 
-document.getElementById("app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const cardEeleteButton = event.target.closest(".card__edit-button");
   if (cardEeleteButton === null) {
     return;
@@ -96,7 +99,7 @@ document.getElementById("app").addEventListener("click", (event) => {
   card.style.display = "none";
 });
 
-document.getElementById("app").addEventListener("dragstart", (event) => {
+setEvent(app, "dragstart", (event) => {
   const draggable = event.target.closest(".card");
   draggable.classList.add("dragging");
 
@@ -105,7 +108,7 @@ document.getElementById("app").addEventListener("dragstart", (event) => {
 
   // TODO: render todo
 });
-document.getElementById("app").addEventListener("dragend", (event) => {
+setEvent(app, "dragend", (event) => {
   const draggable = event.target.closest(".card");
   draggable.classList.remove("dragging");
 
@@ -115,7 +118,7 @@ document.getElementById("app").addEventListener("dragend", (event) => {
   // TODO: render todo
 });
 
-document.getElementById("app").addEventListener("dragover", (event) => {
+setEvent(app, "dragover", (event) => {
   const column = event.target.closest(".column__cards");
   if (column === null) {
     return;

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -3,12 +3,14 @@ import * as Alert from "../alert/index.js";
 import * as EditableCard from "../editable-card/index.js";
 import { getLocalStorage, setLocalStorage } from "../../utils/local-storage.js";
 import { store } from "../../store/index.js";
+import { getDragAfterElement } from "../../utils/get-drag-after-element.js";
 
 export function template({ columnId, card }) {
   return `
   <li data-column-id="${columnId}"
       data-card-id="${card.id}"
       class="card rounded-8 surface-default shadow-normal"
+      draggable="true"
     >
     <div class="card__contents">
         <h3 class="card__title text-strong display-bold14">
@@ -36,16 +38,16 @@ export function template({ columnId, card }) {
 const render = () => {};
 store.subscribe(render);
 
-document.querySelector("#app").addEventListener("click", (event) => {
-  const target = event.target.closest(".card__delete-button");
-  if (target === null) {
+document.getElementById("app").addEventListener("click", (event) => {
+  const cardDeleteButton = event.target.closest(".card__delete-button");
+  if (cardDeleteButton === null) {
     return;
   }
 
   Alert.show({
     message: "선택한 카드를 삭제할까요?",
     onConfirm: () => {
-      const card = target.closest(".card");
+      const card = cardDeleteButton.closest(".card");
       const columnId = card.getAttribute("data-column-id");
       const cardId = card.getAttribute("data-card-id");
 
@@ -60,7 +62,7 @@ document.querySelector("#app").addEventListener("click", (event) => {
       setLocalStorage("todolist", todolist);
 
       // TODO: use dispatch and middleware
-      store.dispatch(deleteCard({ columnId, cardId }));
+      // store.dispatch(deleteCard({ columnId, cardId }));
 
       // NOTE: 특정 칼럼에 대한 카드 리렌더링
       const column = document.querySelector(
@@ -75,13 +77,13 @@ document.querySelector("#app").addEventListener("click", (event) => {
   });
 });
 
-document.querySelector("#app").addEventListener("click", (event) => {
-  const target = event.target.closest(".card__edit-button");
-  if (target === null) {
+document.getElementById("app").addEventListener("click", (event) => {
+  const cardEeleteButton = event.target.closest(".card__edit-button");
+  if (cardEeleteButton === null) {
     return;
   }
 
-  const card = target.closest(".card");
+  const card = cardEeleteButton.closest(".card");
   const columnId = card.getAttribute("data-column-id");
   const cardId = card.getAttribute("data-card-id");
   const title = card.querySelector(".card__title").innerText;
@@ -92,4 +94,37 @@ document.querySelector("#app").addEventListener("click", (event) => {
     EditableCard.template({ columnId, cardId, title, description })
   );
   card.style.display = "none";
+});
+
+document.getElementById("app").addEventListener("dragstart", (event) => {
+  const draggable = event.target.closest(".card");
+  draggable.classList.add("dragging");
+
+  // TODO: patch card
+  // store.dispatch(moveCard({ columnId, cardId }));
+
+  // TODO: render todo
+});
+document.getElementById("app").addEventListener("dragend", (event) => {
+  const draggable = event.target.closest(".card");
+  draggable.classList.remove("dragging");
+
+  // TODO: patch card
+  // store.dispatch(moveCard({ columnId, cardId }));
+
+  // TODO: render todo
+});
+
+document.getElementById("app").addEventListener("dragover", (event) => {
+  const column = event.target.closest(".column__cards");
+  if (column === null) {
+    return;
+  }
+  event.preventDefault();
+  const afterElement = getDragAfterElement({
+    draggableElements: column.querySelectorAll(".card:not(.dragging)"),
+    y: event.clientY,
+  });
+  const draggable = document.querySelector(".dragging");
+  column.insertBefore(draggable, afterElement);
 });

--- a/src/components/card/styles.css
+++ b/src/components/card/styles.css
@@ -38,3 +38,7 @@
   display: flex;
   gap: 8px;
 }
+
+.dragging {
+  opacity: 0.5;
+}

--- a/src/components/column/index.js
+++ b/src/components/column/index.js
@@ -1,5 +1,8 @@
 import * as Card from "../card/index.js";
 import * as AddCard from "../add-card/index.js";
+import { setEvent } from "../../utils/set-event.js";
+
+const app = document.getElementById("app");
 
 export function template({ column }) {
   return `
@@ -27,7 +30,7 @@ export function template({ column }) {
     `;
 }
 
-document.querySelector("#app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const target = event.target.closest(".column__head-plus");
   if (target === null) {
     return;

--- a/src/components/column/styles.css
+++ b/src/components/column/styles.css
@@ -30,6 +30,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  height: 100%;
 }
 
 .badge {

--- a/src/components/editable-card/index.js
+++ b/src/components/editable-card/index.js
@@ -88,9 +88,9 @@ document.querySelector("#app").addEventListener("click", (event) => {
   cards[cardIndex] = newCard;
   setLocalStorage("todolist", todolist);
 
-  store.dispatch({ type: "EDIT_CARD", payload: {} });
+  // store.dispatch({ type: "EDIT_CARD", payload: {} });
   // or
-  store.dispatch(editCard({ columnId, cardId, title, description }));
+  // store.dispatch(editCard({ columnId, cardId, title, description }));
 
   // render
   const card = document.querySelector(`.card[data-card-id="${cardId}"]`);

--- a/src/components/editable-card/index.js
+++ b/src/components/editable-card/index.js
@@ -1,6 +1,8 @@
 import { store } from "../../store/index.js";
 import { getLocalStorage, setLocalStorage } from "../../utils/local-storage.js";
-import * as Column from "../column/index.js";
+import { setEvent } from "../../utils/set-event.js";
+
+const app = document.getElementById("app");
 
 export function template({ columnId, cardId, title, description }) {
   return `
@@ -45,7 +47,7 @@ export function template({ columnId, cardId, title, description }) {
 const render = () => {};
 store.subscribe(render);
 
-document.querySelector("#app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const target = event.target.closest(
     ".card__editable-buttons > .cancel-button"
   );
@@ -61,7 +63,7 @@ document.querySelector("#app").addEventListener("click", (event) => {
   card.style.display = "flex";
 });
 
-document.querySelector("#app").addEventListener("click", (event) => {
+setEvent(app, "click", (event) => {
   const target = event.target.closest(".edit-button");
   if (target === null) {
     return;

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,4 +1,7 @@
 import * as ActionHistoryListDialog from "../action-history-list/index.js";
+import { setEvent } from "../../utils/set-event.js";
+
+const app = document.getElementById("app");
 
 export function template() {
   return `      
@@ -16,9 +19,9 @@ export function render(parent) {
 }
 
 // FIXME 이벤트 위임이 괜찮은가?
-document.querySelector("#app").onclick = (e) => {
+setEvent(app, "click", (e) => {
   const target = e.target.closest("button");
   if (target && target.classList.contains("action-history-open-button")) {
     ActionHistoryListDialog.show();
   }
-};
+});

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,6 +1,7 @@
 import * as ActionHistoryListDialog from "../action-history-list/index.js";
 import { setEvent } from "../../utils/set-event.js";
 
+// FIXME app 전역에 하나 만들어두고 참조하게 할 수는 없을까?
 const app = document.getElementById("app");
 
 export function template() {
@@ -18,7 +19,6 @@ export function render(parent) {
   parent.insertAdjacentHTML("afterbegin", template());
 }
 
-// FIXME 이벤트 위임이 괜찮은가?
 setEvent(app, "click", (e) => {
   const target = e.target.closest("button");
   if (target && target.classList.contains("action-history-open-button")) {

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -1,3 +1,4 @@
+import { historyReducer } from "./history-reducer.js";
 import { todoReducer } from "./todo-reducer.js";
 import { combineReducer } from "../core/combine-reducers.js";
 

--- a/src/utils/get-drag-after-element.js
+++ b/src/utils/get-drag-after-element.js
@@ -1,0 +1,15 @@
+export const getDragAfterElement = ({ draggableElements, y }) => {
+  return [...draggableElements].reduce(
+    (closest, child) => {
+      const box = child.getBoundingClientRect();
+      const offsetY = y - box.top - box.height / 2;
+
+      if (offsetY < 0 && offsetY > closest.offset) {
+        return { offset: offsetY, element: child };
+      } else {
+        return closest;
+      }
+    },
+    { offset: Number.NEGATIVE_INFINITY }
+  ).element;
+};

--- a/src/utils/set-event.js
+++ b/src/utils/set-event.js
@@ -1,0 +1,3 @@
+export const setEvent = (target, event, handler) => {
+  target.addEventListener(event, handler);
+};


### PR DESCRIPTION
## 구현 내용
- 카드 이동 drag & drop
- `setEvent` 유틸 구현

## 고민 사항
- `dragover` 이벤트가 계속 실행되면서 `getDragAfterElement`(드래그 중인 요소 가까이에 있는 요소를 반환하는 함수)연산이 계속 이루어지고 있음. 이 함수에서 drag할 때마다 매 ms마다 근처 element와의 위치를 계산하기 때문에 성능 이슈 우려
- `setEvent` 유틸 함수에서 root 노드(`<div id='app'>`)로 이벤트 위임하는 것까지 추상화해둘지 고민
  - 이벤트 위임 코드가 중복되고 있음.
```js
// 이벤트 위임 코드 반복
document.getElementById('app').addEventListener('click', (event) => {
  const target = event.target.closest('selector'); // NOTE: 실제로 클릭한 요소 가져오기
  ...
})
```

## 기타
